### PR TITLE
Berrycrush

### DIFF
--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -139,7 +139,10 @@ Debug_EventScript_ToggleDayNight::
 	release
 	end
 
-Debug_EventScript_Script_3::
+Debug_EventScript_StartSoloBerryCrush::
+    lockall
+    fadescreenswapbuffers FADE_TO_BLACK
+    special StartBerryCrushSolo
 	release
 	end
 

--- a/data/specials.inc
+++ b/data/specials.inc
@@ -563,3 +563,4 @@ gSpecials::
 	def_special SetGrottoWarp
 	def_special HaveAllSpeciesBeenShown
 	def_special UseBlankMessageToCancelPokemonPic
+    def_special StartBerryCrushSolo

--- a/include/berry_crush.h
+++ b/include/berry_crush.h
@@ -3,6 +3,6 @@
 
 #include "main.h"
 
-void StartBerryCrush(MainCallback exitCallback);
+void StartBerryCrush(MainCallback exitCallback, bool32 isSolo);
 
 #endif // GUARD_BERRY_CRUSH_H

--- a/include/best_of_three.h
+++ b/include/best_of_three.h
@@ -3,7 +3,7 @@
 
 #include "main.h"
 
-void Task_OpenMenuFromStartMenu(u8 taskId);
+void Task_OpenBO3MenuFromStartMenu(u8 taskId);
 void Menu_Init(MainCallback callback);
 
 

--- a/include/field_specials.h
+++ b/include/field_specials.h
@@ -37,5 +37,6 @@ void PreparePartyForSkyBattle(void);
 void GetObjectPosition(u16*, u16*, u32, u32);
 bool32 CheckObjectAtXY(u32, u32);
 bool32 CheckPartyHasSpecies(u32);
+void StartBerryCrushSolo(void);
 
 #endif // GUARD_FIELD_SPECIALS_H

--- a/include/global.h
+++ b/include/global.h
@@ -255,7 +255,7 @@ struct PyramidBag
 
 struct BerryCrush
 {
-    u16 pressingSpeeds[4]; // For the record with each possible group size, 2-5 players
+    u16 pressingSpeeds[5]; // For the record with each possible group size, 2-5 players
     u32 berryPowderAmount;
     u32 unk;
 };

--- a/include/item_menu.h
+++ b/include/item_menu.h
@@ -11,6 +11,7 @@ enum {
     ITEMMENULOCATION_SHOP,
     ITEMMENULOCATION_BERRY_TREE,
     ITEMMENULOCATION_BERRY_BLENDER_CRUSH,
+    ITEMMENULOCATION_BERRY_CRUSH_SOLO,
     ITEMMENULOCATION_ITEMPC,
     ITEMMENULOCATION_FAVOR_LADY,
     ITEMMENULOCATION_QUIZ_LADY,
@@ -100,7 +101,7 @@ void CB2_GoToSellMenu(void);
 void GoToBagMenu(u8 bagMenuType, u8 pocketId, void ( *exitCallback)());
 void DoWallyTutorialBagMenu(void);
 void ResetBagScrollPositions(void);
-void ChooseBerryForMachine(void (*exitCallback)(void));
+void ChooseBerryForMachine(void (*exitCallback)(void), bool32 isSolo);
 void CB2_ChooseBerry(void);
 void CB2_ChooseMulch(void);
 void Task_FadeAndCloseBagMenu(u8 taskId);

--- a/src/berry.c
+++ b/src/berry.c
@@ -1661,6 +1661,13 @@ const struct BerryCrushBerryData gBerryCrush_BerryData[] = {
     [ITEM_APICOT_BERRY - FIRST_BERRY_INDEX]          = {.difficulty = 180, .powder = 500},
     [ITEM_LANSAT_BERRY - FIRST_BERRY_INDEX]          = {.difficulty = 200, .powder = 750},
     [ITEM_STARF_BERRY - FIRST_BERRY_INDEX]           = {.difficulty = 200, .powder = 750},
+    [ITEM_MICLE_BERRY - FIRST_BERRY_INDEX]           = {.difficulty = 200, .powder = 750},
+    [ITEM_CUSTAP_BERRY - FIRST_BERRY_INDEX]          = {.difficulty = 200, .powder = 750},
+    [ITEM_JABOCA_BERRY - FIRST_BERRY_INDEX]          = {.difficulty = 200, .powder = 750},
+    [ITEM_ROWAP_BERRY - FIRST_BERRY_INDEX]           = {.difficulty = 200, .powder = 750},
+    [ITEM_KEE_BERRY - FIRST_BERRY_INDEX]             = {.difficulty = 200, .powder = 750},
+    [ITEM_MARANGA_BERRY - FIRST_BERRY_INDEX]         = {.difficulty = 200, .powder = 750},
+    [ITEM_ENIGMA_BERRY - FIRST_BERRY_INDEX]          = {.difficulty = 150, .powder = 200},
     [ITEM_ENIGMA_BERRY_E_READER - FIRST_BERRY_INDEX] = {.difficulty = 150, .powder = 200}
 };
 

--- a/src/berry_blender.c
+++ b/src/berry_blender.c
@@ -1053,6 +1053,7 @@ void DoBerryBlending(void)
 static void CB2_LoadBerryBlender(void)
 {
     s32 i;
+    bool32 isSolo = gSpecialVar_0x8004;
 
     switch (sBerryBlender->mainState)
     {
@@ -1122,7 +1123,7 @@ static void CB2_LoadBerryBlender(void)
             UnsetBgTilemapBuffer(2);
             UnsetBgTilemapBuffer(1);
             SetVBlankCallback(NULL);
-            ChooseBerryForMachine(StartBlender);
+            ChooseBerryForMachine(StartBlender, isSolo);
 
             sBerryBlender->mainState = 0;
         }
@@ -1630,6 +1631,15 @@ static void CB2_StartBlenderLocal(void)
     switch (sBerryBlender->mainState)
     {
     case 0:
+        if (gSpecialVar_ItemId == ITEM_NONE)
+        {
+            sBerryBlender->playAgainState = PLAY_AGAIN_NO;
+            SetMainCallback2(CB2_CheckPlayAgainLocal);
+            sBerryBlender->gameEndState = 0;
+            sBerryBlender->mainState = 0;
+            break;
+        }
+
         SetWirelessCommType0();
         InitBlenderBgs();
         SetPlayerBerryData(0, gSpecialVar_ItemId);

--- a/src/best_of_three.c
+++ b/src/best_of_three.c
@@ -131,7 +131,7 @@ const u32 sBO3InfoCard_Pal[] = INCBIN_U32("graphics/best_of_three/infocard.gbapa
 
 //==========FUNCTIONS==========//
 // UI loader template
-void Task_OpenMenuFromStartMenu(u8 taskId)
+void Task_OpenBO3MenuFromStartMenu(u8 taskId)
 {
     if (!gPaletteFade.active)
     {

--- a/src/debug.c
+++ b/src/debug.c
@@ -331,8 +331,8 @@ static void Debug_RedrawListMenu(u8 taskId);
 
 static void DebugAction_Util_DayNight(u8 taskId);
 static void DebugAction_Util_CheckMemory(u8 taskId);
-static void DebugAction_Util_Script_3(u8 taskId);
-static void DebugAction_Util_Script_4(u8 taskId);
+static void DebugAction_Util_OpenBO3Menu(u8 taskId);
+static void DebugAction_Util_BerryCrushSolo(u8 taskId);
 static void DebugAction_Util_Script_5(u8 taskId);
 static void DebugAction_Util_Script_6(u8 taskId);
 static void DebugAction_Util_Script_7(u8 taskId);
@@ -461,7 +461,7 @@ extern const u8 Debug_EventScript_CheckIVs[];
 extern const u8 Debug_EventScript_InflictStatus1[];
 extern const u8 Debug_EventScript_ToggleDayNight[];
 extern const u8 Debug_EventScript_CheckMemory[];
-extern const u8 Debug_EventScript_Script_3[];
+extern const u8 Debug_EventScript_StartSoloBerryCrush[];
 extern const u8 Debug_EventScript_Script_4[];
 extern const u8 Debug_EventScript_Script_5[];
 extern const u8 Debug_EventScript_Script_6[];
@@ -512,7 +512,7 @@ static const u8 sDebugText_Cancel[] =        _("Cancel");
 static const u8 sDebugText_Util_DayNight[]      = _("Toggle Day Night");
 static const u8 sDebugText_Util_CheckMemory[]   = _("Check Mon Memory");
 static const u8 sDebugText_Util_Script_3[]      = _("Show BO3 Menu");
-static const u8 sDebugText_Util_Script_4[]      = _("Script 4");
+static const u8 sDebugText_Util_Script_4[]      = _("Start Berry Crush");
 static const u8 sDebugText_Util_Script_5[]      = _("Script 5");
 static const u8 sDebugText_Util_Script_6[]      = _("Script 6");
 static const u8 sDebugText_Util_Script_7[]      = _("Script 7");
@@ -936,8 +936,8 @@ static void (*const sDebugMenu_Actions_Scripts[])(u8) =
 {
     [DEBUG_UTIL_MENU_ITEM_SCRIPT_1] = DebugAction_Util_DayNight,
     [DEBUG_UTIL_MENU_ITEM_SCRIPT_2] = DebugAction_Util_CheckMemory,
-    [DEBUG_UTIL_MENU_ITEM_SCRIPT_3] = DebugAction_Util_Script_3,
-    [DEBUG_UTIL_MENU_ITEM_SCRIPT_4] = DebugAction_Util_Script_4,
+    [DEBUG_UTIL_MENU_ITEM_SCRIPT_3] = DebugAction_Util_OpenBO3Menu,
+    [DEBUG_UTIL_MENU_ITEM_SCRIPT_4] = DebugAction_Util_BerryCrushSolo,
     [DEBUG_UTIL_MENU_ITEM_SCRIPT_5] = DebugAction_Util_Script_5,
     [DEBUG_UTIL_MENU_ITEM_SCRIPT_6] = DebugAction_Util_Script_6,
     [DEBUG_UTIL_MENU_ITEM_SCRIPT_7] = DebugAction_Util_Script_7,
@@ -2387,14 +2387,14 @@ static void DebugAction_Util_CheckMemory(u8 taskId)
     Debug_DestroyMenu_Full_Script(taskId, Debug_EventScript_CheckMemory);
 }
 
-static void DebugAction_Util_Script_3(u8 taskId)
+static void DebugAction_Util_OpenBO3Menu(u8 taskId)
 {
-    Task_OpenMenuFromStartMenu(taskId);
+    Task_OpenBO3MenuFromStartMenu(taskId);
 }
 
-static void DebugAction_Util_Script_4(u8 taskId)
+static void DebugAction_Util_BerryCrushSolo(u8 taskId)
 {
-    Debug_DestroyMenu_Full_Script(taskId, Debug_EventScript_Script_4);
+    Debug_DestroyMenu_Full_Script(taskId, Debug_EventScript_StartSoloBerryCrush);
 }
 
 static void DebugAction_Util_Script_5(u8 taskId)

--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -3,6 +3,7 @@
 #include "malloc.h"
 #include "battle.h"
 #include "battle_tower.h"
+#include "berry_crush.h"
 #include "cable_club.h"
 #include "data.h"
 #include "decoration.h"
@@ -4405,4 +4406,9 @@ void SetRoofBirds(void)
             }
         }
     }
+}
+
+void StartBerryCrushSolo(void)
+{
+    StartBerryCrush(CB2_LoadMap, TRUE);
 }

--- a/src/item_menu.c
+++ b/src/item_menu.c
@@ -391,6 +391,7 @@ static const TaskFunc sContextMenuFuncs[] = {
     [ITEMMENULOCATION_SHOP] =                   Task_ItemContext_Sell,
     [ITEMMENULOCATION_BERRY_TREE] =             Task_FadeAndCloseBagMenu,
     [ITEMMENULOCATION_BERRY_BLENDER_CRUSH] =    Task_ItemContext_Normal,
+    [ITEMMENULOCATION_BERRY_CRUSH_SOLO] =       Task_ItemContext_Normal,
     [ITEMMENULOCATION_ITEMPC] =                 Task_ItemContext_Deposit,
     [ITEMMENULOCATION_FAVOR_LADY] =             Task_ItemContext_Normal,
     [ITEMMENULOCATION_QUIZ_LADY] =              Task_ItemContext_Normal,
@@ -795,9 +796,12 @@ void CB2_ChooseMulch(void)
 }
 
 // Choosing berry for Berry Blender or Berry Crush
-void ChooseBerryForMachine(void (*exitCallback)(void))
+void ChooseBerryForMachine(void (*exitCallback)(void), bool32 isSolo)
 {
-    GoToBagMenu(ITEMMENULOCATION_BERRY_BLENDER_CRUSH, BERRIES_POCKET, exitCallback);
+    if (isSolo)
+        GoToBagMenu(ITEMMENULOCATION_BERRY_CRUSH_SOLO, BERRIES_POCKET, exitCallback);
+    else
+        GoToBagMenu(ITEMMENULOCATION_BERRY_BLENDER_CRUSH, BERRIES_POCKET, exitCallback);
 }
 
 void CB2_GoToSellMenu(void)
@@ -847,6 +851,7 @@ void GoToBagMenu(u8 location, u8 pocket, void ( *exitCallback)())
             gBagPosition.pocket = pocket;
         if (gBagPosition.location == ITEMMENULOCATION_BERRY_TREE ||
             gBagPosition.location == ITEMMENULOCATION_BERRY_BLENDER_CRUSH ||
+            gBagPosition.location == ITEMMENULOCATION_BERRY_CRUSH_SOLO ||
             gBagPosition.location == ITEMMENULOCATION_BERRY_TREE_MULCH)
             gBagMenu->pocketSwitchDisabled = TRUE;
         gBagMenu->newScreenCallback = NULL;
@@ -1798,6 +1803,7 @@ static void OpenContextMenu(u8 taskId)
         }
         break;
     case ITEMMENULOCATION_BERRY_BLENDER_CRUSH:
+    case ITEMMENULOCATION_BERRY_CRUSH_SOLO:
         gBagMenu->contextMenuItemsPtr = sContextMenuItems_BerryBlenderCrush;
         gBagMenu->contextMenuNumItems = ARRAY_COUNT(sContextMenuItems_BerryBlenderCrush);
         break;

--- a/src/strings.c
+++ b/src/strings.c
@@ -211,6 +211,7 @@ const u8 *const gBagMenu_ReturnToStrings[] =
     [ITEMMENULOCATION_SHOP]                = gText_TheShop,
     [ITEMMENULOCATION_BERRY_TREE]          = gText_TheField,
     [ITEMMENULOCATION_BERRY_BLENDER_CRUSH] = gText_TheField,
+    [ITEMMENULOCATION_BERRY_CRUSH_SOLO]    = gText_TheField,
     [ITEMMENULOCATION_ITEMPC]              = gText_ThePC,
     [ITEMMENULOCATION_FAVOR_LADY]          = gText_TheField,
     [ITEMMENULOCATION_QUIZ_LADY]           = gText_TheField,

--- a/src/union_room.c
+++ b/src/union_room.c
@@ -1732,7 +1732,7 @@ static void Task_StartActivity(u8 taskId)
         break;
     case ACTIVITY_BERRY_CRUSH:
         WarpForWirelessMinigame(USING_BERRY_CRUSH, 9, 1);
-        StartBerryCrush(CB2_LoadMap);
+        StartBerryCrush(CB2_LoadMap, FALSE);
         break;
     case ACTIVITY_BERRY_PICK:
         WarpForWirelessMinigame(USING_MINIGAME, 5, 1);

--- a/tools/learnset_helpers/porymoves_files/b2w2.json
+++ b/tools/learnset_helpers/porymoves_files/b2w2.json
@@ -80324,7 +80324,7 @@
       "MOVE_ZEN_HEADBUTT"
     ]
   },
-  "WORMADAM_SANDY_CLOAK": {
+  "WORMADAM_SANDY": {
     "LevelMoves": [
       {
         "Level": 1,
@@ -80426,7 +80426,7 @@
       "MOVE_UPROAR"
     ]
   },
-  "WORMADAM_TRASH_CLOAK": {
+  "WORMADAM_TRASH": {
     "LevelMoves": [
       {
         "Level": 1,

--- a/tools/learnset_helpers/porymoves_files/bdsp.json
+++ b/tools/learnset_helpers/porymoves_files/bdsp.json
@@ -55908,7 +55908,7 @@
     "EggMoves": [],
     "TutorMoves": []
   },
-  "WORMADAM_SANDY_CLOAK": {
+  "WORMADAM_SANDY": {
     "LevelMoves": [
       {
         "Level": 0,
@@ -56023,7 +56023,7 @@
     "EggMoves": [],
     "TutorMoves": []
   },
-  "WORMADAM_TRASH_CLOAK": {
+  "WORMADAM_TRASH": {
     "LevelMoves": [
       {
         "Level": 0,

--- a/tools/learnset_helpers/porymoves_files/bw.json
+++ b/tools/learnset_helpers/porymoves_files/bw.json
@@ -72003,7 +72003,7 @@
     "EggMoves": [],
     "TutorMoves": []
   },
-  "WORMADAM_SANDY_CLOAK": {
+  "WORMADAM_SANDY": {
     "LevelMoves": [
       {
         "Level": 1,
@@ -72094,7 +72094,7 @@
     "EggMoves": [],
     "TutorMoves": []
   },
-  "WORMADAM_TRASH_CLOAK": {
+  "WORMADAM_TRASH": {
     "LevelMoves": [
       {
         "Level": 1,

--- a/tools/learnset_helpers/porymoves_files/dp.json
+++ b/tools/learnset_helpers/porymoves_files/dp.json
@@ -53246,7 +53246,7 @@
     "EggMoves": [],
     "TutorMoves": []
   },
-  "WORMADAM_SANDY_CLOAK": {
+  "WORMADAM_SANDY": {
     "LevelMoves": [
       {
         "Level": 1,
@@ -53335,7 +53335,7 @@
     "EggMoves": [],
     "TutorMoves": []
   },
-  "WORMADAM_TRASH_CLOAK": {
+  "WORMADAM_TRASH": {
     "LevelMoves": [
       {
         "Level": 1,

--- a/tools/learnset_helpers/porymoves_files/hgss.json
+++ b/tools/learnset_helpers/porymoves_files/hgss.json
@@ -59645,7 +59645,7 @@
       "MOVE_ZEN_HEADBUTT"
     ]
   },
-  "WORMADAM_SANDY_CLOAK": {
+  "WORMADAM_SANDY": {
     "LevelMoves": [
       {
         "Level": 1,
@@ -59749,7 +59749,7 @@
       "MOVE_UPROAR"
     ]
   },
-  "WORMADAM_TRASH_CLOAK": {
+  "WORMADAM_TRASH": {
     "LevelMoves": [
       {
         "Level": 1,

--- a/tools/learnset_helpers/porymoves_files/la.json
+++ b/tools/learnset_helpers/porymoves_files/la.json
@@ -17281,7 +17281,7 @@
     "EggMoves": [],
     "TutorMoves": []
   },
-  "WORMADAM_SANDY_CLOAK": {
+  "WORMADAM_SANDY": {
     "LevelMoves": [
       {
         "Level": 1,
@@ -17326,7 +17326,7 @@
       "MOVE_STEALTH_ROCK"
     ]
   },
-  "WORMADAM_TRASH_CLOAK": {
+  "WORMADAM_TRASH": {
     "LevelMoves": [
       {
         "Level": 1,

--- a/tools/learnset_helpers/porymoves_files/oras.json
+++ b/tools/learnset_helpers/porymoves_files/oras.json
@@ -94735,7 +94735,7 @@
       "MOVE_ZEN_HEADBUTT"
     ]
   },
-  "WORMADAM_SANDY_CLOAK": {
+  "WORMADAM_SANDY": {
     "LevelMoves": [
       {
         "Level": 1,
@@ -94840,7 +94840,7 @@
       "MOVE_UPROAR"
     ]
   },
-  "WORMADAM_TRASH_CLOAK": {
+  "WORMADAM_TRASH": {
     "LevelMoves": [
       {
         "Level": 1,

--- a/tools/learnset_helpers/porymoves_files/pt.json
+++ b/tools/learnset_helpers/porymoves_files/pt.json
@@ -58146,7 +58146,7 @@
       "MOVE_ZEN_HEADBUTT"
     ]
   },
-  "WORMADAM_SANDY_CLOAK": {
+  "WORMADAM_SANDY": {
     "LevelMoves": [
       {
         "Level": 1,
@@ -58248,7 +58248,7 @@
       "MOVE_UPROAR"
     ]
   },
-  "WORMADAM_TRASH_CLOAK": {
+  "WORMADAM_TRASH": {
     "LevelMoves": [
       {
         "Level": 1,

--- a/tools/learnset_helpers/porymoves_files/sm.json
+++ b/tools/learnset_helpers/porymoves_files/sm.json
@@ -95978,7 +95978,7 @@
     "EggMoves": [],
     "TutorMoves": []
   },
-  "WORMADAM_SANDY_CLOAK": {
+  "WORMADAM_SANDY": {
     "LevelMoves": [
       {
         "Level": 0,
@@ -96093,7 +96093,7 @@
     "EggMoves": [],
     "TutorMoves": []
   },
-  "WORMADAM_TRASH_CLOAK": {
+  "WORMADAM_TRASH": {
     "LevelMoves": [
       {
         "Level": 0,

--- a/tools/learnset_helpers/porymoves_files/sv.json
+++ b/tools/learnset_helpers/porymoves_files/sv.json
@@ -95417,14 +95417,14 @@
     "EggMoves": [],
     "TutorMoves": []
   },
-  "WORMADAM_SANDY_CLOAK": {
+  "WORMADAM_SANDY": {
     "LevelMoves": [],
     "PreEvoMoves": [],
     "TMMoves": [],
     "EggMoves": [],
     "TutorMoves": []
   },
-  "WORMADAM_TRASH_CLOAK": {
+  "WORMADAM_TRASH": {
     "LevelMoves": [],
     "PreEvoMoves": [],
     "TMMoves": [],

--- a/tools/learnset_helpers/porymoves_files/usum.json
+++ b/tools/learnset_helpers/porymoves_files/usum.json
@@ -107351,7 +107351,7 @@
       "MOVE_ZEN_HEADBUTT"
     ]
   },
-  "WORMADAM_SANDY_CLOAK": {
+  "WORMADAM_SANDY": {
     "LevelMoves": [
       {
         "Level": 0,
@@ -107478,7 +107478,7 @@
       "MOVE_UPROAR"
     ]
   },
-  "WORMADAM_TRASH_CLOAK": {
+  "WORMADAM_TRASH": {
     "LevelMoves": [
       {
         "Level": 0,

--- a/tools/learnset_helpers/porymoves_files/xy.json
+++ b/tools/learnset_helpers/porymoves_files/xy.json
@@ -84805,7 +84805,7 @@
     "EggMoves": [],
     "TutorMoves": []
   },
-  "WORMADAM_SANDY_CLOAK": {
+  "WORMADAM_SANDY": {
     "LevelMoves": [
       {
         "Level": 1,
@@ -84899,7 +84899,7 @@
     "EggMoves": [],
     "TutorMoves": []
   },
-  "WORMADAM_TRASH_CLOAK": {
+  "WORMADAM_TRASH": {
     "LevelMoves": [
       {
         "Level": 1,


### PR DESCRIPTION
Adds a Single Player option to Berry Crush for use through the `StartBerryCrush` function.

Includes allowing the player to cancel berry selection if playing Single Player since this will not impact any link partners.

Also added this feature to Berry Blending since it was available.

Finally, also fixes Burmy definitions because I forgot to switch brances.