### PR TITLE
fixes TurboA issues by toggling off dialogue on CB

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -205,6 +205,8 @@ void SetMainCallback2(MainCallback callback)
 {
     gMain.callback2 = callback;
     gMain.state = 0;
+    if (callback != CB2_Overworld)
+        gMain.activeOverworldDialog = FALSE;
 }
 
 void StartTimer1(void)


### PR DESCRIPTION
Prevents TurboA from doing anything it shouldn't by disabling during CBs other than Overworld